### PR TITLE
Feature/babel workarounds

### DIFF
--- a/base/code/src/state/models/User.ts
+++ b/base/code/src/state/models/User.ts
@@ -1,8 +1,16 @@
-import { Model, prop } from 'datx';
+import { IRawModel, Model, prop, PureCollection } from 'datx';
 
 export class User extends Model {
   public static type = 'user';
 
   @prop
   public name!: string;
+
+  // Workaround for a babel issue (feature?)
+  constructor(data?: IRawModel, collection?: PureCollection) {
+    super(data, collection);
+    if (data) {
+      this.update(data);
+    }
+  }
 }

--- a/modules/jsonapi/code/state/models/User.ts
+++ b/modules/jsonapi/code/state/models/User.ts
@@ -1,4 +1,4 @@
-import { Model, prop } from 'datx';
+import { IRawModel, Model, prop, PureCollection } from 'datx';
 import { jsonapi } from 'datx-jsonapi';
 
 export class User extends jsonapi(Model) {
@@ -6,4 +6,12 @@ export class User extends jsonapi(Model) {
 
   @prop
   public name!: string;
+
+  // Workaround for a babel issue (feature?)
+  constructor(data?: IRawModel, collection?: PureCollection) {
+    super(data, collection);
+    if (data) {
+      this.update(data);
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
     "commander": "^2.19.0",
     "fs-extra": "^7.0.1",
     "lodash": "^4.17.11",
-    "progress": "^2.0.1"
+    "progress": "^2.0.3"
   },
   "devDependencies": {
     "@types/commander": "^2.12.2",
     "@types/fs-extra": "^5.0.4",
-    "@types/lodash": "^4.14.118",
-    "@types/progress": "^2.0.1"
+    "@types/lodash": "^4.14.119",
+    "@types/progress": "^2.0.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,17 +14,19 @@
   dependencies:
     "@types/node" "*"
 
-"@types/lodash@^4.14.118":
-  version "4.14.118"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.118.tgz#247bab39bfcc6d910d4927c6e06cbc70ec376f27"
+"@types/lodash@^4.14.119":
+  version "4.14.119"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.119.tgz#be847e5f4bc3e35e46d041c394ead8b603ad8b39"
+  integrity sha512-Z3TNyBL8Vd/M9D9Ms2S3LmFq2sSMzahodD6rCS9V2N44HUMINb75jNkSuwAx7eo2ufqTdfOdtGQpNbieUjPQmw==
 
 "@types/node@*":
   version "10.12.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.9.tgz#a07bfa74331471e1dc22a47eb72026843f7b95c8"
 
-"@types/progress@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@types/progress/-/progress-2.0.1.tgz#af866001a836dbd28a6656e4b335d333bad7faf2"
+"@types/progress@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/progress/-/progress-2.0.3.tgz#7ccbd9c6d4d601319126c469e73b5bb90dfc8ccc"
+  integrity sha512-bPOsfCZ4tsTlKiBjBhKnM8jpY5nmIll166IPD58D92hR7G7kZDfx5iB9wGF4NfZrdKolebjeAr3GouYkSGoJ/A==
   dependencies:
     "@types/node" "*"
 
@@ -54,9 +56,10 @@ lodash@^4.17.11:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
-progress@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.1.tgz#c9242169342b1c29d275889c95734621b1952e31"
+progress@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
 universalify@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
This is a workaround for either a babel issue or the new spec (I was not able to confirm either). I'm hoping to find a better solution than to add boilerplate to each model, but this works for now.

# The issue
```typescript
class Foo {
  constructor(data) {
    this.update(data);
  }

  public update(data) {
    Object.assign(this, data); // A simple example to show what DatX is doing when creating a model (+ a lot more)
  }
}

class Bar extends Foo {
  public a: number;
  public b: string;
}

const bar = new Bar({ a: 1, b: 2 });
console.log(bar.a); // undefined
console.log(bar.b); // undefined
```

# Why does that happen
When transpiling the class properties, Babel does the following (not the exact code, but it's the gist):
```typescript
class Bar extends Foo {
  public a: number;
  public b: string;

  constructor(...args) {
    super(...args);
    this.a = undefined; // Because it is undefined in this class...
    this.b = undefined;
  }
}
```

# What does the fix do
```typescript
class Bar extends Foo {
  public a: number;
  public b: string;

  constructor(...args) {
    super(...args);
    this.a = undefined; // Because it is undefined in this class...
    this.b = undefined;
    if (data) {
      this.update(data); // Set the defaults in the Foo class again :/
    }
  }
}
```