### PR TITLE
Remove the workaround code

### DIFF
--- a/base/code/src/state/models/User.ts
+++ b/base/code/src/state/models/User.ts
@@ -1,4 +1,4 @@
-import { IRawModel, Model, prop, PureCollection } from 'datx';
+import { Model, prop } from 'datx';
 
 export class User extends Model {
   public static type = 'user';

--- a/base/code/src/state/models/User.ts
+++ b/base/code/src/state/models/User.ts
@@ -5,12 +5,4 @@ export class User extends Model {
 
   @prop
   public name!: string;
-
-  // Workaround for a babel issue (feature?)
-  constructor(data?: IRawModel, collection?: PureCollection) {
-    super(data, collection);
-    if (data) {
-      this.update(data);
-    }
-  }
 }

--- a/modules/jsonapi/code/state/models/User.ts
+++ b/modules/jsonapi/code/state/models/User.ts
@@ -6,12 +6,4 @@ export class User extends jsonapi(Model) {
 
   @prop
   public name!: string;
-
-  // Workaround for a babel issue (feature?)
-  constructor(data?: IRawModel, collection?: PureCollection) {
-    super(data, collection);
-    if (data) {
-      this.update(data);
-    }
-  }
 }

--- a/modules/jsonapi/code/state/models/User.ts
+++ b/modules/jsonapi/code/state/models/User.ts
@@ -1,4 +1,4 @@
-import { IRawModel, Model, prop, PureCollection } from 'datx';
+import { Model, prop } from 'datx';
 import { jsonapi } from 'datx-jsonapi';
 
 export class User extends jsonapi(Model) {


### PR DESCRIPTION
No need for the workaround code with DatX 0.15.11 (https://github.com/infinum/datx/commit/d681f69634ba0f5b15a3b9fac6629cbe01886771) 🎉

Also, the `@prop` decorator should now behave as expected in all situations.